### PR TITLE
Update DMCA form filling

### DIFF
--- a/js/g_writer.js
+++ b/js/g_writer.js
@@ -146,7 +146,7 @@ chrome.storage.local.get(function (items) {
         'input[name="company"]',
         'input[name="organization"]',
         '#company'
-      ]) || pickByLabel(['組織名', 'Organization name']),
+      ]) || pickByLabel(['組織名', '会社名', 'Organization name']),
       items.m_company
     );
     manual(


### PR DESCRIPTION
## Summary
- add Japanese label `会社名` when locating the organization input

## Testing
- `grep -n "会社名" -n js/g_writer.js`

------
https://chatgpt.com/codex/tasks/task_e_6875cb0aeafc83298fc3fe511086d1ae