### PR TITLE
Add blur event dispatch to inputs

### DIFF
--- a/js/g_writer.js
+++ b/js/g_writer.js
@@ -19,7 +19,7 @@ chrome.storage.local.get(function (items) {
       ['input', 'change', 'blur'].forEach(ev => el.dispatchEvent(new Event(ev, { bubbles: true })));
     } else {
       el.value = val;
-      ['input', 'change'].forEach(ev => el.dispatchEvent(new Event(ev, { bubbles: true })));
+      ['input', 'change', 'blur'].forEach(ev => el.dispatchEvent(new Event(ev, { bubbles: true }))); 
     }
   }
 


### PR DESCRIPTION
## Summary
- dispatch `'blur'` events for `<input>` and `<textarea>` elements in `g_writer.js`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687683b1e5a0832980063ae89cd4c10f